### PR TITLE
Some fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
-CC=g++
 SRC=main.cpp
-FLAGS=-std=c++11 -O3 -stdlib=libc++ -fwhole-program -DNDEBUG -s
+FLAGS=-std=c++11 -O3 -fwhole-program -s -lpthread
 OUTPUT=calcpi.o
 
-all:
-	$(CC) $(SRC) -o $(OUTPUT) $(FLAGS) -march=native
+all: $(SRC)
+	$(CXX) $< -o $(OUTPUT) $(FLAGS) -march=native
 
 clean:
 	-rm calcpi.*

--- a/main.cpp
+++ b/main.cpp
@@ -1,11 +1,8 @@
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 // these two are to get maximums
-#include <limits.h>
-#include <float.h>
 #include <thread>
 #include <future>
-#include <ctime>
 #include <chrono>
 #include <cmath>
 #include <iostream>
@@ -20,7 +17,7 @@ std::uint_fast64_t cycles = UINT_FAST64_MAX;
 
 void calcinrange(std::uint_fast64_t start, std::uint_fast64_t end, std::promise<long double> && r, int TID) {
 	std::uint_fast64_t cycle = start;
-	long double dParts[3] = {2.0l+(long double)(start*2), 3.0l+(long double)(start*2), 4.0l+(long double)(start*2)};
+	long double dParts[3] = {2.0l+static_cast<long double>(start*2), 3.0l+static_cast<long double>(start*2), 4.0l+static_cast<long double>(start*2)};
 	long double pi = 0.0l; // the smaller ones will start with 0, then they will all be added to 3 at the end
 	bool add = true;
 	while (cycle <= end) {
@@ -33,38 +30,38 @@ void calcinrange(std::uint_fast64_t start, std::uint_fast64_t end, std::promise<
 		add = !add;
 	}
 	r.set_value(pi);
-	printf("Thread %d done.\n", TID);
+	std::printf("Thread %d done.\n", TID);
 }
 
 int main(int argc, char* argv[]) {
 	int threads = 1;
 	int precision = 11; // this will be 10 decimal places. 1 is added for the 3
 	if (argc >= 4) {
-		precision = std::abs(atoi(argv[3]));
+	    precision = std::abs(std::atoi(argv[3]));
 		if (precision > 50) {
-			printf("Warning: %d is equivalent to a precision of 50.\n", precision);
+			std::printf("Warning: %d is equivalent to a precision of 50.\n", precision);
 			precision = 51; // again, add one for 3
 		}
-		threads = atoi(argv[1]);
-		sscanf(argv[2], "%" SCNuFAST64 "", &cycles);
+		threads = std::atoi(argv[1]);
+		std::sscanf(argv[2], "%" SCNuFAST64 "", &cycles);
 	} else if (argc == 3) {
-		threads = atoi(argv[1]);
-		sscanf(argv[2], "%" SCNuFAST64 "", &cycles);
+		threads = std::atoi(argv[1]);
+		std::sscanf(argv[2], "%" SCNuFAST64 "", &cycles);
 	} else if (argc == 2) {
-		threads = atoi(argv[1]);
+		threads = std::atoi(argv[1]);
 	}
 
 	if (threads <= 0)
-		threads = (int)std::thread::hardware_concurrency();
+	    threads = static_cast<int>(std::thread::hardware_concurrency());
 
 	if (threads <= 0) { // this means that it couldn't figure out how many threads the system can have
-		printf("Warning: could not determine hardware concurrency. Please specify a specific number of threads. Will use one thread.\n");
+		std::printf("Warning: could not determine hardware concurrency. Please specify a specific number of threads. Will use one thread.\n");
 		threads = 1;
 	}
 
-	printf("Calculating pi over %" PRIuFAST64 " iterations.\nUsing %d threads.\nPrecision: %d decimal places.\n", cycles, threads, precision-1);
+	std::printf("Calculating pi over %" PRIuFAST64 " iterations.\nUsing %d threads.\nPrecision: %d decimal places.\n", cycles, threads, precision-1);
 
-	high_resolution_clock::time_point t1 = high_resolution_clock::now();
+	steady_clock::time_point t1 = steady_clock::now();
 
 	std::vector<std::thread> t(threads);
 	std::vector<std::promise<long double> > p(threads);
@@ -77,27 +74,23 @@ int main(int argc, char* argv[]) {
 		std::uint_fast64_t start = 0+(TID*(cycles/threads));
 		std::uint_fast64_t end = start+(cycles/threads)-1;
 		t[TID] = std::thread(calcinrange, start, end, std::move(p[TID]), TID);
-		printf("Thread %d: %" PRIuFAST64 " to %" PRIuFAST64 "\n", TID, start, end);
+		std::printf("Thread %d: %" PRIuFAST64 " to %" PRIuFAST64 "\n", TID, start, end);
 	}
-	printf("Started.\n");
-
-	long double *returns = new long double[threads];
-	for (int i = 0; i < threads; i++) {
-		t[i].join();
-		returns[i] = futures[i].get();
-	}
-
-	printf("All threads completed.\n");
+	std::printf("Started.\n");
 
 	long double answer = 3.0l;
-	for (int i = 0; i < threads; i++)
-		answer += returns[i];
-	
-	high_resolution_clock::time_point t2 = high_resolution_clock::now();
+	for (int i = 0; i < threads; i++) {
+		t[i].join();
+		answer += futures[i].get();
+	}
+
+	std::printf("All threads completed.\n");
+
+	steady_clock::time_point t2 = steady_clock::now();
 	duration<double> time_span = duration_cast<duration<double>>(t2 - t1);
 
 	std::cout << "Answer: " << std::setprecision(precision) << answer;
-	printf(" (took %.2f seconds)\n", time_span.count());
+	std::printf(" (took %.2f seconds)\n", time_span.count());
 	
 	return 0;
 }


### PR DESCRIPTION
Hey.
I saw your post on reddit. I've been interested how have you done calculations in parallel without openmp. I liked this approach.

I reviewed the code and made little changes:
* there was a memory leak of the `returns` array, furthermore, it wasn't actually necessary. I removed it; `answer` now accumulated in the same loop where numbers acquired from the futures.
* replaced `high_resolution_clock` by `steady_clock`, the latter one is recommended for measuring intervals http://en.cppreference.com/w/cpp/chrono/steady_clock
* fixed flags in Makefile: removed `-stdlib` as it's clang option only; removed useless `-DNDEBUG`: there is no NDEBUG macro in the code.
* replaced c-like type casts and other non-critical refactoring: functions with namespaces are more distinguishable and can be easily located and replaced.